### PR TITLE
Exclude plugin bootstrap from the test coverage

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -29,5 +29,6 @@
 
 	<logging>
 		<log type="coverage-clover" target="tests/reports/clover.xml" />
+		<log type="coverage-text" target="php://stdout" />
 	</logging>
 </phpunit>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,6 +18,7 @@
 		<whitelist processUncoveredFilesFromWhitelist="false">
 			<directory suffix=".php">./</directory>
 			<exclude>
+				<file>./plugin.php</file>
 				<directory suffix=".php">./node_modules</directory>
 				<directory suffix=".php">./tests</directory>
 				<directory suffix=".php">./vendor</directory>

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,6 @@
 # Block Extend
 
 [![Build Status](https://travis-ci.com/xwp/block-extend.svg?branch=master)](https://travis-ci.com/xwp/block-extend)
-
 [![Coverage Status](https://coveralls.io/repos/github/xwp/block-extend/badge.svg?branch=master)](https://coveralls.io/github/xwp/block-extend?branch=master)
 
 

--- a/tests/php/PluginTest.php
+++ b/tests/php/PluginTest.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace XWP\BlockExtendTest;
+
+use WP_Mock;
+use XWP\BlockExtend\Plugin;
+
+/**
+ * Test the WordPress plugin abstraction.
+ */
+class PluginTest extends BlockExtendTestCase {
+
+	/**
+	 * Test the plugin setup.
+	 *
+	 * @covers XWP\BlockExtend\Plugin::__construct()
+	 * @covers XWP\BlockExtend\Plugin::file()
+	 * @covers XWP\BlockExtend\Plugin::dir()
+	 */
+	public function test_plugin_init() {
+		WP_Mock::userFunction( 'wp_upload_dir' )
+			->once()
+			->with( null, false );
+
+		$plugin = new Plugin( '/absolute/path/to/plugin.php' );
+
+		$this->assertEquals( '/absolute/path/to/plugin.php', $plugin->file() );
+		$this->assertEquals( '/absolute/path/to', $plugin->dir() );
+	}
+
+	/**
+	 * Test the plugin setup.
+	 *
+	 * @covers XWP\BlockExtend\Plugin::basename()
+	 */
+	public function test_basename() {
+		$mock = WP_Mock::userFunction( 'plugin_basename' )->twice();
+
+		$mock->with( '/any/random/file.js' )->andReturn( 'plugins/any/random/file.js' );
+
+		$plugin = new Plugin( '/path/to/plugin/file.php' );
+
+		$this->assertEquals(
+			'plugins/any/random/file.js',
+			$plugin->basename( '/any/random/file.js' ),
+			'Asks WP API to return the basename for a file'
+		);
+
+		$mock->with( '/path/to/plugin/file.php' )->andReturn( 'plugins/plugin/file.php' );
+
+		$this->assertEquals(
+			'plugins/plugin/file.php',
+			$plugin->basename(),
+			'Defaults to the main plugin file for the basename'
+		);
+	}
+
+}

--- a/tests/php/PluginTest.php
+++ b/tests/php/PluginTest.php
@@ -34,6 +34,7 @@ class PluginTest extends BlockExtendTestCase {
 	 * @covers XWP\BlockExtend\Plugin::basename()
 	 */
 	public function test_basename() {
+		// Is there a way to do this using withArgs() and andReturnValues()?
 		$mock = WP_Mock::userFunction( 'plugin_basename' )->twice();
 
 		$mock->with( '/any/random/file.js' )->andReturn( 'plugins/any/random/file.js' );


### PR DESCRIPTION
- Exclude `plugin.php` from phpunit coverage report since there is nothing to test.