### PR TITLE
Ensure an Asset Version is Always Present

### DIFF
--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -164,7 +164,7 @@ class Plugin {
 	public function meta( $field = null ) {
 		static $meta;
 
-		if ( ! isset( $meta ) ) {
+		if ( ! isset( $meta ) && function_exists( 'get_plugin_data' ) ) {
 			$meta = get_plugin_data( $this->file );
 		}
 

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -85,6 +85,16 @@ class Plugin {
 	}
 
 	/**
+	 * Get the path to the asset file.
+	 *
+	 * @param string $path_relative Path relative to this plugin directory root.
+	 * @return string The path to the asset.
+	 */
+	public function asset_path( $path_relative = '' ) {
+		return plugin_dir_path( $this->file ) . $path_relative;
+	}
+
+	/**
 	 * Get absolute path to a file in the uploads directory.
 	 *
 	 * @param  string $path_relative File path relative to the root of the WordPress uploads directory.

--- a/php/Plugin.php
+++ b/php/Plugin.php
@@ -154,14 +154,26 @@ class Plugin {
 	/**
 	 * Sync the plugin version with the asset version.
 	 *
+	 * @param string $file Path to the file for which to check modified time.
+	 *
 	 * @return string
 	 */
-	public function asset_version() {
+	public function asset_version( $file = false ) {
 		if ( $this->is_debug() || $this->is_script_debug() ) {
-			return time();
+			return (string) time();
 		}
 
-		return $this->version();
+		$version = $this->version();
+
+		if ( empty( $version ) ) {
+			if ( ! empty( $file ) && file_exists( $file ) ) {
+				$version = (string) filemtime( $file );
+			} else {
+				$version = $GLOBALS['wp_version'];
+			}
+		}
+
+		return $version;
 	}
 
 	/**


### PR DESCRIPTION
Fixes #12 

This pull request ensures that when using the `$plugin->asset_version()` method, a version will always be output.